### PR TITLE
Improve quartile highlight and normalization workflow

### DIFF
--- a/impacto.js
+++ b/impacto.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:418e586388bc6d3dbfb0c07e12fb93d31d7c6e7ccaf8ddc044f63ac85d13ca88
-size 36303
+oid sha256:ae1188fe60c18d0bc96a1b440f0d9bcd5408041c4fa7a8a21786e696be1e3b46
+size 36337

--- a/index.html
+++ b/index.html
@@ -199,42 +199,42 @@
                         <div class="card-body">
                             <div class="row g-3">
                                 <div class="col-6 col-lg-3">
-                                    <div class="card text-center p-2 border-success h-100">
+                                    <div class="card text-center p-2 border-success bg-success-subtle h-100">
                                         <small data-bs-toggle="tooltip" title="25% de municipios con mejor puntaje">Q1
                                             (Mejor)</small>
                                         <div id="q1-count" class="fs-5 fw-bold text-success">-</div>
-                                        <button class="btn btn-sm btn-outline-success mt-1" id="q1-toggle"
+                                        <button class="btn btn-sm btn-outline-success quartile-btn mt-1" id="q1-toggle"
                                             data-bs-toggle="tooltip" title="Ver/Ocultar en Mapa"><i
                                                 class="bi bi-eye-fill"></i></button>
                                     </div>
                                 </div>
                                 <div class="col-6 col-lg-3">
-                                    <div class="card text-center p-2 border-warning h-100">
+                                    <div class="card text-center p-2 border-warning bg-warning-subtle h-100">
                                         <small data-bs-toggle="tooltip"
                                             title="Municipios entre el 25% y 50% de puntaje">Q2</small>
                                         <div id="q2-count" class="fs-5 fw-bold text-warning">-</div>
-                                        <button class="btn btn-sm btn-outline-warning mt-1" id="q2-toggle"
+                                        <button class="btn btn-sm btn-outline-warning quartile-btn mt-1" id="q2-toggle"
                                             data-bs-toggle="tooltip" title="Ver/Ocultar en Mapa"><i
                                                 class="bi bi-eye-fill"></i></button>
                                     </div>
                                 </div>
                                 <div class="col-6 col-lg-3">
-                                    <div class="card text-center p-2 h-100" style="border-color: #E67E22;">
+                                    <div class="card text-center p-2 h-100" style="border-color: #E67E22; background-color: #fcebd8;">
                                         <small data-bs-toggle="tooltip"
                                             title="Municipios entre el 50% y 75% de puntaje">Q3</small>
                                         <div id="q3-count" class="fs-5 fw-bold" style="color: #E67E22;">-</div>
-                                        <button class="btn btn-sm mt-1" id="q3-toggle" data-bs-toggle="tooltip"
+                                        <button class="btn btn-sm quartile-btn mt-1" id="q3-toggle" data-bs-toggle="tooltip"
                                             title="Ver/Ocultar en Mapa"
                                             style="border-color: #E67E22; color: #E67E22;"><i
                                                 class="bi bi-eye-fill"></i></button>
                                     </div>
                                 </div>
                                 <div class="col-6 col-lg-3">
-                                    <div class="card text-center p-2 border-danger h-100">
+                                    <div class="card text-center p-2 border-danger bg-danger-subtle h-100">
                                         <small data-bs-toggle="tooltip" title="25% de municipios con peor puntaje">Q4
                                             (Peor)</small>
                                         <div id="q4-count" class="fs-5 fw-bold text-danger">-</div>
-                                        <button class="btn btn-sm btn-outline-danger mt-1" id="q4-toggle"
+                                        <button class="btn btn-sm btn-outline-danger quartile-btn mt-1" id="q4-toggle"
                                             data-bs-toggle="tooltip" title="Ver/Ocultar en Mapa"><i
                                                 class="bi bi-eye-fill"></i></button>
                                     </div>


### PR DESCRIPTION
## Summary
- Restore color highlight for quartile summary cards and register quartile toggle buttons
- Automatically normalize weights before applying calculations and clear validation
- Run impact calculator after normalizing to keep results up to date

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1b624e08832fbc33259a3f745c8a